### PR TITLE
Add tests for iterating over panel positions

### DIFF
--- a/panels/tests/test_PanelSizeLocator.py
+++ b/panels/tests/test_PanelSizeLocator.py
@@ -23,7 +23,7 @@ import pytest
 
 from panels import PanelSizeLocator
 from panels.tests import (check_panels_in_figure, gridsize_st, length_st,
-                          offset_st)
+                          offset_st, almost_equal)
 
 
 #: Length units to generate test cases for.
@@ -199,3 +199,27 @@ def test_with_pad_and_sep(rows, columns, panelwidth, panelheight, hsep, vsep,
     assert figheight == (padtop + rows * panelheight +
                          (rows - 1) * vsep + padbottom)
     check_panels_in_figure(l)
+
+
+#-----------------------------------------------------------------------
+# Tests for iterating over panels.
+#-----------------------------------------------------------------------
+
+@given(rows=gridsize_st, columns=gridsize_st)
+def test_iterate_row_major(rows, columns):
+    l = PanelSizeLocator(rows, columns, 1, 1)
+    dx = 1. / columns
+    dy = 1. / rows
+    for n, pp in enumerate(l.panel_position_iterator()):
+        assert almost_equal((n % columns) * dx, pp[0])
+        assert almost_equal(1 - (n // columns + 1) * dy, pp[1])
+
+
+@given(rows=gridsize_st, columns=gridsize_st)
+def test_iterate_column_major(rows, columns):
+    l = PanelSizeLocator(rows, columns, 1, 1)
+    dx = 1. / columns
+    dy = 1. / rows
+    for n, pp in enumerate(l.panel_position_iterator(order='column')):
+        assert almost_equal((n // rows) * dx, pp[0])
+        assert almost_equal(1 - (n % rows + 1) * dy, pp[1])


### PR DESCRIPTION
Hi @SimonPeatman. I've written two tests for panel iteration to help you along, one for row-major and one for column-major iteration. The tests use the keyword `order` instead of `major` but other than that they should be independent of implementation.